### PR TITLE
Add rofi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,43 +13,44 @@ A simple tool that prints man pages in a PDF file (with vim keys support) for an
 ## Description
 
 A simple tool that prints (or saves) man pages in a PDF file via [Zathura](https://pwmt.org/projects/zathura/) for an easier reading.  
-It also allows you to navigate through all the man pages available on your system via [Dmenu](https://tools.suckless.org/dmenu/).
+It also allows you to navigate through all the man pages available on your system via [Rofi](https://davatorium.github.io/rofi/) or [Dmenu](https://tools.suckless.org/dmenu/).
 
 ## Installation
 
 ### AUR
 
 Install the [zaman](https://aur.archlinux.org/packages/zaman) AUR package.  
-Make sure you also have a zathura PDF backend installed (either [zathura-pdf-poppler](https://archlinux.org/packages/community/x86_64/zathura-pdf-poppler/) or [zathura-pdf-mupdf](https://archlinux.org/packages/community/x86_64/zathura-pdf-mupdf/)).
+Make sure you also have a zathura PDF backend installed (either [zathura-pdf-poppler](https://archlinux.org/packages/community/x86_64/zathura-pdf-poppler/) or [zathura-pdf-mupdf](https://archlinux.org/packages/community/x86_64/zathura-pdf-mupdf/)) as well as a dynamic menu (either [rofi](https://archlinux.org/packages/community/x86_64/rofi/) or [dmenu](https://archlinux.org/packages/community/x86_64/dmenu/)).
 
 ### From Source
 
 Install dependencies:  
   
 - Replace `zathura-pdf-poppler` by `zathura-pdf-mupdf` if you prefer to use the `mupdf` backend.
+- Replace `rofi` by `dmenu` if you prefer to use that (it's called `suckless-tools` on Debian/Ubuntu).
 
 #### Debian/Ubuntu
 
 ```
-sudo apt install man-db groff zathura zathura-pdf-poppler suckless-tools
+sudo apt install man-db groff zathura zathura-pdf-poppler rofi
 ```
 
 #### RedHat/Fedora
 
 ```
-sudo dnf install man-db groff groff-perl "perl(Compress::Zlib)" zathura zathura-pdf-poppler dmenu
+sudo dnf install man-db groff groff-perl "perl(Compress::Zlib)" zathura zathura-pdf-poppler rofi
 ```
 
 #### Arch Linux
 
 ```
-sudo pacman -S man-db groff zathura zathura-pdf-poppler dmenu
+sudo pacman -S man-db groff zathura zathura-pdf-poppler rofi
 ```
 
 #### Gentoo
 
 ```
-sudo emerge man-db groff zathura zathura-pdf-poppler dmenu
+sudo emerge man-db groff zathura zathura-pdf-poppler rofi
 ```
   
 Download the archive of the [latest stable release](https://github.com/Antiz96/zaman/releases/latest) and extract it *(alternatively, you can clone this repository via `git`)*.  
@@ -66,60 +67,68 @@ sudo make uninstall
 
 ## Usage
 
-Run the `zaman` command in your terminal to display a list/menu in which you can navigate through all the available man pages on your system with your keyboard (up and down arrow keys and type search):    
+Run the `zaman` command in your terminal to display a list of all the available man pages on your system (via [Rofi](https://davatorium.github.io/rofi/) or [Dmenu](https://tools.suckless.org/dmenu/)), allowing you to search for the one to print as a PDF.  
 
 ![zaman](https://user-images.githubusercontent.com/53110319/183697489-cd2b8c1e-334c-42f3-be8d-2c0b4a7e002c.png)
 
-Alternatively, you can specify the man page to open directly in the command (example below with the "ls" man page):  
+Alternatively, you can directly specify the man page to open in the command (example below with the "ls" man page):  
 
 ![zaman_with_argument](https://user-images.githubusercontent.com/53110319/183697495-25951c0d-fc93-4606-a9bf-712739272460.png)
 
-The man page will open in fullscreen as a PDF file in [Zathura](https://pwmt.org/projects/zathura/) (which has vim keys and mousewheel support). Just press `q` to quit, as you would normally do when reading a man page:  
+The man page will open in fullscreen as a PDF file in [Zathura](https://pwmt.org/projects/zathura/). Just press `q` to quit, as you would normally do when reading a man page:  
 
 ![zaman_ls](https://user-images.githubusercontent.com/53110319/183697494-2c268494-64cd-414f-a942-cac7a87580ba.png)
 
+You can save a specific man page in a PDF file called "man_<command>.pdf" in your current directory with the `-O` (or `--save`) option:  
+
+
+
+Or, you can specify the destination file with the `-o` (or `--output`) option:  
+
+
+
 ## Documentation
 
-See the documentation below:
-
-*The documentation is also available as a man page and with the "--help" function.*  
-*Run `man zaman` or `zaman --help` (or even `zaman zaman` actually :smile:) after you've installed the **zaman** package.*  
+See the documentation below:  
+  
+*The documentation is also available as a man page and with the "--help" option.*  
+*Run `man zaman` or `zaman --help` (or even `zaman zaman` actually :smile:) after you've installed the `zaman` package.*  
     
 ### SYNOPSIS
 
-zaman [OPTION] [MAN PAGE TO DISPLAY]
+zaman [OPTION] [MAN PAGE]
 
 ### DESCRIPTION
 
-A simple tool that prints man pages in a PDF file (with vim keys support) via [Zathura](https://pwmt.org/projects/zathura/) for an easier reading.  
-It also allows you to select the man page to display through a list of all the available man pages on your system via [Dmenu](https://tools.suckless.org/dmenu/).
+A simple tool that prints (or saves) man pages in a PDF file via [Zathura](https://pwmt.org/projects/zathura/) for an easier reading.  
+It also allows you to navigate through all the man pages available on your system via [Rofi](https://davatorium.github.io/rofi/) or [Dmenu](https://tools.suckless.org/dmenu/).
 
 ### OPTIONS
 
-If no option is passed, print the list of all the available man pages on the system, allowing you to search and select the one to print as a PDF.  
+If no option is passed, print the list of all the available man pages on the system in a dynamic menu (rofi or dmenu); allowing you to search for the one to print as a PDF.  
   
-You can also specify the man page to open directly in the command:
+Alternatively, you can directly specify the man page to open in the command (example below with the "ls" man page):  
 ```
 zaman ls
 ```
 
 #### -o, --output "file"
 
-Write output to "file". Useful to save the PDF converted man page to a file of your choice:
+Write the output to "file". Useful to save the PDF converted man page to a file of your choice:
 ```
 zaman -o ls ~/Documents/man/ls.pdf
 ```
 
 #### -O, --save
 
-Write output to a local file named "man_`command`.pdf". Useful to quickly save the PDF converted man page to a local file:
+Write the output to a PDF file named "man_`command`.pdf" inside your current directory. Useful to quickly save the PDF converted man page to a file:
   
-You can either select the man page to save as a PDF file via the dmenu list:
+You can either select the man page to save as a PDF file via the rofi/dmenu list:
 ```
 zaman -O
 ```
   
-Or you can specify the man page to save as a PDF file directly in the command:
+Or you can directly specify the man page to save as a PDF file in the command:
 ```
 zaman -O ls
 ``` 
@@ -140,7 +149,7 @@ if OK
 
 #### 1
 
-if problems (user tried to open a non-existing man page...)
+if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, ...)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,22 +69,23 @@ sudo make uninstall
 
 Run the `zaman` command in your terminal to display a list of all the available man pages on your system (via [Rofi](https://davatorium.github.io/rofi/) or [Dmenu](https://tools.suckless.org/dmenu/)), allowing you to search for the one to print as a PDF.  
 
-![zaman](https://user-images.githubusercontent.com/53110319/183697489-cd2b8c1e-334c-42f3-be8d-2c0b4a7e002c.png)
+![zaman](https://user-images.githubusercontent.com/53110319/226755165-3080f232-cb9f-4d5b-aa06-b18032cd8eaa.png)
 
 Alternatively, you can directly specify the man page to open in the command (example below with the "ls" man page):  
 
-![zaman_with_argument](https://user-images.githubusercontent.com/53110319/183697495-25951c0d-fc93-4606-a9bf-712739272460.png)
+![zaman_cmd](https://user-images.githubusercontent.com/53110319/226755190-9d005cbe-b893-4b96-b6c1-db97a70f3a4b.png)
 
 The man page will open in fullscreen as a PDF file in [Zathura](https://pwmt.org/projects/zathura/). Just press `q` to quit, as you would normally do when reading a man page:  
 
-![zaman_ls](https://user-images.githubusercontent.com/53110319/183697494-2c268494-64cd-414f-a942-cac7a87580ba.png)
+![zaman_pdf](https://user-images.githubusercontent.com/53110319/226755232-e8cdadd6-e0a4-473b-857e-3b3273f4ad0f.png)
 
-You can save a specific man page in a PDF file called "man_<command>.pdf" in your current directory with the `-O` (or `--save`) option:  
+You can save a specific man page in a PDF file called "man_`command`.pdf" in your current directory with the `-O` (or `--save`) option *(if you run `zaman -O` without specifying a man page to save, `zaman` will offer you to select one via rofi/dmenu)*:  
 
+![zaman_save](https://user-images.githubusercontent.com/53110319/226755247-637c4827-9940-43e4-88e9-4978152e4cc4.png)
 
+Alternatively, you can specify the destination file with the `-o` (or `--output`) option:  
 
-Or, you can specify the destination file with the `-o` (or `--output`) option:  
-
+![zaman_output](https://user-images.githubusercontent.com/53110319/226755261-cb4bf006-fae3-48ea-8187-8c4e1772b7b0.png)
 
 
 ## Documentation

--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -12,7 +12,7 @@ A simple tool that prints (or saves) man pages in a PDF file via Zathura for an 
 
 .SH OPTIONS
 .PP
-.RB "  If no option is passed, print the list of all the available man pages on the system in a dynamic menu (rofi or dmenu); allowing you to search for the one to print as a PDF."
+.RB "If no option is passed, print the list of all the available man pages on the system in a dynamic menu (rofi or dmenu); allowing you to search for the one to print as a PDF."
 .br
 .br
 .RB "Alternatively, you can directly specify the man page to open in the command:"

--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -1,40 +1,40 @@
-.TH "ZAMAN" "1" "September 2022" "Zaman v1" "Zaman Manual"
+.TH "ZAMAN" "1" "March 2023" "Zaman v1" "Zaman Manual"
 
 .SH NAME
-zaman \- A simple tool that prints man pages in a PDF file (with vim keys support) for an easier reading.
+zaman \- A simple tool that prints (or saves) man pages in a PDF file for an easier reading.
 
 .SH SYNOPSIS
 .B zaman
 [\fI\,OPTION\/\fR] [\fI\,MAN PAGE\/\fR]
 
 .SH DESCRIPTION
-A simple tool that prints man pages in a PDF file (with vim keys support) via Zathura for an easier reading. It also allows you to select the man page to display through a list of all the available man pages on your system via Dmenu.
+A simple tool that prints (or saves) man pages in a PDF file via Zathura for an easier reading. It also allows you to navigate through all the man pages available on your system via Rofi or Dmenu.
 
 .SH OPTIONS
 .PP
-.RB "If no option is passed, print the list of all the available man pages on the system, allowing you to search and select the one to print as a PDF."
+.RB "  If no option is passed, print the list of all the available man pages on the system in a dynamic menu (rofi or dmenu); allowing you to search for the one to print as a PDF."
 .br
 .br
-.RB "You can also specify the man page to open directly in the command :"
+.RB "Alternatively, you can directly specify the man page to open in the command:"
 .br
 .RB "zaman 'man page to open', e.g.: zaman ls"
 .PP
 
 .TP
 .B \-o, \-\-output <file>
-Write output to "file". Useful to save the PDF converted man page to a file of your choice:
+Write the output to "file". Useful to save the PDF converted man page to a file of your choice:
 .br
 e.g.: "zaman -o ls ~/Documents/man/ls.pdf"
 
 .TP
 .B \-O, \-\-save
-Write output to a local file named "man_<command>.pdf". Useful to quickly save the PDF converted man page to a local file:
+Write the output to a PDF file named "man_<command>.pdf" inside your current directory. Useful to quickly save the PDF converted man page to a file:
 .br
-You can either select the man page to save as a PDF file via the dmenu list:
+You can either select the man page to save as a PDF file via the rofi/dmenu list:
 .br
 e.g.: "zaman -O"
 .br
-Or you can specify the man page to save as a PDF file directly in the command:
+Or you can directly specify the man page to save as a PDF file in the command:
 .br
 e.g.: "zaman -O ls"
 
@@ -53,10 +53,11 @@ if OK
 
 .TP
 .B 1
-if problems (user tried to open a non-existing man page...)
+if problems (user tried to open a non-existing man page, user does not have any dynamic manu installed, ...)
 
 .SH SEE ALSO
 .BR zathura (1),
+.BR rofi (1),
 .BR dmenu (1),
 .BR groff (1),
 .BR echo (1),

--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -53,7 +53,7 @@ if OK
 
 .TP
 .B 1
-if problems (user tried to open a non-existing man page, user does not have any dynamic manu installed, ...)
+if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, ...)
 
 .SH SEE ALSO
 .BR zathura (1),

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -53,7 +53,7 @@ else
 					case "${answer}" in
 						[Yy])
 							man -Tpdf "${man_selected}" > "${file}"
-							echo "The ${man_selected} man page has been saved to the ${file} file"
+							echo -e "\nThe ${man_selected} man page has been saved to the ${file} file"
 							exit 0
 						;;
 						*)
@@ -101,7 +101,7 @@ else
 					case "${answer}" in
 						[Yy])
 							man -Tpdf "${man_selected}" > "${file}"
-							echo "The ${man_selected} man page has been saved to the ${file} file"
+							echo -e "\nThe ${man_selected} man page has been saved to the ${file} file"
 							exit 0
 						;;
 						*)

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -3,39 +3,47 @@
 #Current version
 version="1.1.0"
 
-#Rename the $1 var by "man_selected" just to make the script more readable/less complex
-man_selected="${1}"
-
 #If the argument passed to the "zaman" command matches an available man page, print it to a PDF file via "zathura"
-if man -k . | awk '{print $1}' | grep -iq ^"${man_selected}"$ ; then
-	man -Tpdf "${man_selected}" | zathura --mode=fullscreen -
+if man -k . | awk '{print $1}' | grep -iq ^"${1}"$ ; then
+	man -Tpdf "${1}" | zathura --mode=fullscreen -
 	exit 0
 else
-	#If the argument passed to the "zaman" command does not match an available man page, rename the $1 var by "option" just to make the script more readable/less complex
+	#If the argument passed to the "zaman" command does not match an available man page, rename the $1 var to "option" just to make the script more readable/less complex
 	option="${1}"
+
 	case "${option}" in
-		#If no option is passed to the "zaman" command, print the list of available man pages through "dmenu" and print the selected one to a PDF file via "zathura"
+		#If no option is passed to the "zaman" command, print the list of available man pages through "rofi" or "dmenu"
 		"")
-			man_selected=$(man -k . | awk '{print $1}' | dmenu -l 15)
+			if command -v rofi > /dev/null; then
+				man_selected=$(man -k . | awk '{print $1}' | rofi -dmenu -sort)
+			elif command -v dmenu > /dev/null; then
+				man_selected=$(man -k . | awk '{print $1}' | dmenu -l 15)
+			else
+				echo -e >&2 "A dynamic menu is required to print the list of available man pages\nPlease, install rofi or dmenu"
+				exit 1
+			fi
 			
+			#If the selected/inputted man page exists, print it to a PDF file via "zathura"
 			if man -k . | awk '{print $1}' | grep -iq ^"${man_selected}"$ ; then
 				man -Tpdf "${man_selected}" | zathura --mode=fullscreen -
 				exit 0
+			#If the selected/inputted man page does not exists, print an error
 			else
 				man "${man_selected}"
 				echo >&2 "Try 'zaman --help' for more information."
 				exit 1
 			fi
 		;;
-		#If the -o (or --output) option is passed to the "zaman" command, save the output to the specified file
+		#If the -o (or --output) option is passed to the "zaman" command, save the specified man page to the specified PDF file
 		-o|--output)
 			man_selected="${2}"
 			file="${3}"
-			 
+			
 			if man -k . | awk '{print $1}' | grep -iq ^"${man_selected}"$ ; then
-				#If the specified file does not exists, create it and redirect output to it
+				#If the specified file does not exists, create it and save the specified man page rendered as a PDF in it
 				if [ ! -f "${file}" ]; then
 					man -Tpdf "${man_selected}" > "${file}"
+					echo "The ${man_selected} man page has been saved to the ${file} file"
 					exit 0
 				#If the specified file already exists, ask for the user's confirmation to overwrite its content
 				else
@@ -45,6 +53,7 @@ else
 					case "${answer}" in
 						[Yy])
 							man -Tpdf "${man_selected}" > "${file}"
+							echo "The ${man_selected} man page has been saved to the ${file} file"
 							exit 0
 						;;
 						*)
@@ -53,37 +62,46 @@ else
 						;;
 					esac
 				fi
-			#If the specified man page does not match any available man page, show an error
+			#If the specified man page does not match any available man page, print an error
 			else
 				man "${man_selected}"
 				echo >&2 "Try 'zaman --help' for more information."
 				exit 1
 			fi
 		;;
-		#If the -O (or --save) option is passed to the "zaman" command, save the output to a local file named "man_<command>.pdf"
+		#If the -O (or --save) option is passed to the "zaman" command, save the specified man page to a PDF file named "man_<command>.pdf" in the current directory
 		-O|--save)
 			man_selected="${2}"
 			
-			#If the man page to save hasn't been specified by the user, print the list of available man pages through "dmenu" and save the selected one to a PDF file
+			#If the man page to save hasn't been specified by the user, print the list of available man pages through "rofi" or "dmenu"
 			if [ -z "${man_selected}" ]; then
-				man_selected=$(man -k . | awk '{print $1}' | dmenu -l 15)
+				if command -v rofi > /dev/null; then
+					man_selected=$(man -k . | awk '{print $1}' | rofi -dmenu -sort)
+				elif command -v dmenu > /dev/null; then
+					man_selected=$(man -k . | awk '{print $1}' | dmenu -l 15)
+				else
+					echo -e >&2 "A dynamic menu is required to print the list of available man pages\nPlease, install rofi or dmenu"
+					exit 1
+				fi
 			fi
 
+			#If the selected/inputted man page exists, save it to a PDF file named "man_<command>.pdf" in the current directory
 			if man -k . | awk '{print $1}' | grep -iq ^"${man_selected}"$ ; then
 				file="man_${man_selected}.pdf"
-				#If the "man_<command>.pdf" file does not exists, create it and redirect output to it
+				#If the "man_<command>.pdf" file does not exists, create it and save the specified man page rendered as a PDF in it
 				if [ ! -f "${file}" ]; then
 					man -Tpdf "${man_selected}" > "${file}"
-					echo "The man page has been saved in the \"${file}\" file"
+					echo "The ${man_selected} man page has been saved to the ${file} file"
 					exit 0
 				#If the specified file already exists, ask for the user's confirmation to overwrite its content
 				else
-					echo "The \"${file}\" file already exists."
+					echo "The ${file} file already exists."
 					read -rp $'Do you want to overwrite its content? [y/N] ' answer
 
 					case "${answer}" in
 						[Yy])
 							man -Tpdf "${man_selected}" > "${file}"
+							echo "The ${man_selected} man page has been saved to the ${file} file"
 							exit 0
 						;;
 						*)
@@ -92,7 +110,7 @@ else
 						;;
 					esac
 				fi
-			#If the specified man page does not match any available man page, show an error
+			#If the specified man page does not match any available man page, print an error
 			else
 				man "${man_selected}"
 				echo >&2 "Try 'zaman --help' for more information."


### PR DESCRIPTION
This PR aims to add `rofi` support (in addition of `dmenu`) to generate the dynamic menu showing the list of available man pages and allowing the user to select one.

It also include some minor improvements to the main script.