### PR TITLE
Print a proper error if no man page or file path is specified when using the output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ if OK
 
 #### 1
 
-if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, ...)
+if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, user did not specify a man page or a file path when using the output option...)
 
 ## Contributing
 

--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -53,7 +53,7 @@ if OK
 
 .TP
 .B 1
-if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, ...)
+if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, user did not specify a man page or a file path when using the output option...)
 
 .SH SEE ALSO
 .BR zathura (1),

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -12,8 +12,9 @@ else
 	option="${1}"
 
 	case "${option}" in
-		#If no option is passed to the "zaman" command, print the list of available man pages through "rofi" or "dmenu"
+		#If no option is passed to the "zaman" command, show the list of available man pages and print the selected one as a PDF
 		"")
+			#Print the list of available man pages through "rofi" or "dmenu"
 			if command -v rofi > /dev/null; then
 				man_selected=$(man -k . | awk '{print $1}' | rofi -dmenu -sort)
 			elif command -v dmenu > /dev/null; then
@@ -38,7 +39,14 @@ else
 		-o|--output)
 			man_selected="${2}"
 			file="${3}"
-			
+
+			#If the user didn't specified a man page or a file path, print an error and exit
+			if [ -z "${man_selected}" ] || [ -z "${file}" ]; then
+				echo -e >&2 "Please, specify a man page to export and a file to save it to:\nzaman -o man_page /path/to/file"
+				exit 1
+			fi
+		
+			#If the specified man page exists, save it to the specified file 
 			if man -k . | awk '{print $1}' | grep -iq ^"${man_selected}"$ ; then
 				#If the specified file does not exists, create it and save the specified man page rendered as a PDF in it
 				if [ ! -f "${file}" ]; then

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -42,7 +42,7 @@ else
 
 			#If the user didn't specified a man page or a file path, print an error and exit
 			if [ -z "${man_selected}" ] || [ -z "${file}" ]; then
-				echo -e >&2 "Please, specify a man page to export and a file to save it to:\nzaman -o man_page /path/to/file"
+				echo >&2 "Please, specify a man page to export and a file to save it to: zaman -o man_page /path/to/file"
 				exit 1
 			fi
 		


### PR DESCRIPTION
This PR aims to show a proper error and exit if the user does not specify a man page or a file path when using the output option (`zaman -o man_page /path/to/file`).