### PR TITLE
Stop opening PDF man pages in fullscreen mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Alternatively, you can directly specify the man page to open in the command (exa
 
 ![zaman_cmd](https://user-images.githubusercontent.com/53110319/226755190-9d005cbe-b893-4b96-b6c1-db97a70f3a4b.png)
 
-The man page will open in fullscreen as a PDF file in [Zathura](https://pwmt.org/projects/zathura/). Just press `q` to quit, as you would normally do when reading a man page:  
+The man page will open as a PDF file in [Zathura](https://pwmt.org/projects/zathura/). Just press `q` to quit, as you would normally do when reading a man page:  
 
 ![zaman_pdf](https://user-images.githubusercontent.com/53110319/226755232-e8cdadd6-e0a4-473b-857e-3b3273f4ad0f.png)
 

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -5,7 +5,7 @@ version="1.1.0"
 
 #If the argument passed to the "zaman" command matches an available man page, print it to a PDF file via "zathura"
 if man -k . | awk '{print $1}' | grep -iq ^"${1}"$ ; then
-	man -Tpdf "${1}" | zathura --mode=fullscreen -
+	man -Tpdf "${1}" | zathura -
 	exit 0
 else
 	#If the argument passed to the "zaman" command does not match an available man page, rename the $1 var to "option" just to make the script more readable/less complex
@@ -26,7 +26,7 @@ else
 			
 			#If the selected/inputted man page exists, print it to a PDF file via "zathura"
 			if man -k . | awk '{print $1}' | grep -iq ^"${man_selected}"$ ; then
-				man -Tpdf "${man_selected}" | zathura --mode=fullscreen -
+				man -Tpdf "${man_selected}" | zathura -
 				exit 0
 			#If the selected/inputted man page does not exists, print an error
 			else


### PR DESCRIPTION
This PR serves to make `zaman` stop opening PDF man pages in fullscreen mode by default (which turned out to be not really practical and annoying).