### PR TITLE
Add a clear and concise help message (instead of simply printing the man page) for the --help option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,70 +87,21 @@ Alternatively, you can specify the destination file with the `-o` (or `--output`
 
 ![zaman_output](https://user-images.githubusercontent.com/53110319/226755261-cb4bf006-fae3-48ea-8187-8c4e1772b7b0.png)
 
-
 ## Documentation
 
-See the documentation below:  
-  
-*The documentation is also available as a man page and with the "--help" option.*  
-*Run `man zaman` or `zaman --help` (or even `zaman zaman` actually :smile:) after you've installed the `zaman` package.*  
-    
-### SYNOPSIS
-
-zaman [OPTION] [MAN PAGE]
-
-### DESCRIPTION
-
-A simple tool that prints (or saves) man pages in a PDF file via [Zathura](https://pwmt.org/projects/zathura/) for an easier reading.  
-It also allows you to navigate through all the man pages available on your system via [Rofi](https://davatorium.github.io/rofi/) or [Dmenu](https://tools.suckless.org/dmenu/).
-
-### OPTIONS
-
-If no option is passed, print the list of all the available man pages on the system in a dynamic menu (rofi or dmenu); allowing you to search for the one to print as a PDF.  
-  
-Alternatively, you can directly specify the man page to open in the command (example below with the "ls" man page):  
 ```
-zaman ls
-```
+Directly specify the man page to print as a PDF in the command: zaman 'man page to open'
+e.g.: zaman ls
 
-#### -o, --output "file"
-
-Write the output to "file". Useful to save the PDF converted man page to a file of your choice:
-```
-zaman -o ls ~/Documents/man/ls.pdf
-```
-
-#### -O, --save
-
-Write the output to a PDF file named "man_`command`.pdf" inside your current directory. Useful to quickly save the PDF converted man page to a file:
-  
-You can either select the man page to save as a PDF file via the rofi/dmenu list:
-```
-zaman -O
+Options:
+  -m, --menu                      Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)
+  -o, --output <man page> <file>  Save <man page> into the <file> PDF file
+  -O, --save <man page>           Save <man page> into the "man_<man page>.pdf" file in the current directory; if <man page> isn't specified, open a menu via rofi or dmenu that lists every man pages to choose from
+  -h, --help                      Display this message and exit
+  -V, --version                   Display version information and exit
 ```
   
-Or you can directly specify the man page to save as a PDF file in the command:
-```
-zaman -O ls
-``` 
-
-#### -v, --version
-
-Print the current version
-
-#### -h, --help
-
-Print the help
-
-### EXIT STATUS
-
-#### 0
-
-if OK
-
-#### 1
-
-if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, user did not specify a man page or a file path when using the output option...)
+For more information, see the zaman(1) man page
 
 ## Contributing
 

--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -1,4 +1,4 @@
-.TH "ZAMAN" "1" "March 2023" "Zaman v1" "Zaman Manual"
+.TH "ZAMAN" "1" "June 2023" "Zaman v1" "Zaman Manual"
 
 .SH NAME
 zaman \- A simple tool that prints (or saves) man pages in a PDF file for an easier reading.
@@ -62,11 +62,7 @@ if problems (user tried to open a non-existing man page, user does not have any 
 .BR dmenu (1),
 .BR groff (1),
 .BR echo (1),
-.BR grep (1),
-.BR man (1),
-.BR col (1),
-.br
-The documentation is also available on the GitHub page https://github.com/Antiz96/zaman
+.BR grep (1)
 
 .SH BUGS
 Please report bugs to the GitHub page https://github.com/Antiz96/zaman

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -13,7 +13,23 @@ file="${3}"
 
 # Definition of the help function: Print the help message
 help() {
-	man ${name} | col
+	cat <<EOF
+${name} v${version}
+
+A simple cli tool that prints (or saves) man pages in a PDF file for an easier reading.
+
+Directly specify the man page to print as a PDF in the command: ${name} 'man page to open'
+e.g.: ${name} ls
+
+Options:
+  -m, --menu                      Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)
+  -o, --output <man page> <file>  Save <man page> into the <file> PDF file
+  -O, --save <man page>           Save <man page> into the "man_<man page>.pdf" file in the current directory; if <man page> isn't specified, open a menu via rofi or dmenu that lists every man pages to choose from
+  -h, --help                      Display this message and exit
+  -V, --version                   Display version information and exit
+
+For more information, see the ${name}(1) man page
+EOF
 }
 
 # Definition of the version function: Print the current version


### PR DESCRIPTION
This PR aims to add a clear and concise help message instead of simply printing the man page for the --help option.