### PR TITLE
Use separated exit codes for each type of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zaman
 
-A simple tool that prints man pages in a PDF file (with vim keys support) for an easier reading.
+A simple cli tool that prints (or saves) man pages in a PDF file for an easier reading.
 
 ## Table of contents
 
@@ -99,6 +99,13 @@ Options:
   -O, --save <man page>           Save <man page> into the "man_<man page>.pdf" file in the current directory; if <man page> isn't specified, open a menu via rofi or dmenu that lists every man pages to choose from
   -h, --help                      Display this message and exit
   -V, --version                   Display version information and exit
+
+Exit codes:
+0  OK
+1  Invalid option or man page
+2  Neither `rofi` nor `dmenu` are installed
+3  User didn't gave the confirmation to proceed
+4  User didn't specified a man page or a file to save it to in the -o/--output option
 ```
   
 For more information, see the zaman(1) man page

--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -50,11 +50,23 @@ Print the help
 .SH EXIT STATUS
 .TP
 .B 0
-if OK
+OK
 
 .TP
 .B 1
-if problems (user tried to open a non-existing man page, user does not have any dynamic menu installed, user did not specify a man page or a file path when using the output option...)
+Invalid option or man page
+
+.TP
+.B 2
+Neither `rofi` nor `dmenu` are installed
+
+.TP
+.B 3
+User didn't gave the confirmation to proceed
+
+.TP
+.B 4
+User didn't specified a man page or a file to save it to in the -o/--output option
 
 .SH SEE ALSO
 .BR zathura (1),

--- a/src/script/zaman.sh
+++ b/src/script/zaman.sh
@@ -65,7 +65,7 @@ menu() {
 		man_selected=$(man -k . | awk '{print $1}' | dmenu -l 15)
 	else
 		echo -e >&2 "A dynamic menu is required to print the list of available man pages\nPlease, install rofi or dmenu"
-		exit 1
+		exit 2
 	fi
 }
 
@@ -83,21 +83,20 @@ save_to_file() {
 			;;
 			*)
 				echo -e >&2 "\nAborting"
-				exit 1
+				exit 3
 			;;
 		esac
 	fi
 
 	man -Tpdf "${man_selected}" > "${file}"
 	echo "The ${man_selected} man page has been saved to the ${file} file"
-	exit 0
 }
 
 # Definition of the output function: Save the man page to the specified PDF file
 output() {
 	if [ -z "${man_selected}" ] || [ -z "${file}" ]; then
 		echo -e >&2 "Please, specify a man page to export and a file to save it to: ${name} -o man_page /path/to/file\nTry '${name} --help' for more information."
-		exit 1
+		exit 4
 	fi
 
 	save_to_file


### PR DESCRIPTION
This PR aims to make use of separated exit codes for each type of errors in order to simplify potential debugging.