### PR TITLE
Use complete version ref in man page

### DIFF
--- a/doc/man/zaman.1
+++ b/doc/man/zaman.1
@@ -1,4 +1,4 @@
-.TH "ZAMAN" "1" "June 2023" "Zaman v1" "Zaman Manual"
+.TH "ZAMAN" "1" "June 2023" "Zaman 1.2.2" "Zaman Manual"
 
 .SH NAME
 zaman \- A simple tool that prints (or saves) man pages in a PDF file for an easier reading.


### PR DESCRIPTION
It feels clearer to have the actual complete version reference in the man page, specifically when options/features are added or remove.