### PR TITLE
Add a trust path for users

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# Maintainers
+
+This file contains the maintainers that are trusted and are allowed to cut and sign git tags and release artifacts for this project.  
+As a user, you can *(and should)* verify that git tags and auto-generated source tarballs on releases (tar.gz archives) for this project are signed by one of the person listed below (with the associated GPG key).
+
+If a git tag or an auto-generated source tarball (tar.gz archive) contained in a release of this project cannot be verified (e.g. it is not signed / it is signed with a GPG key or by a person that is not listed below), the associated tag/release/artifact(s) should not be trusted.
+
+Current maintainers:
+
+| Name | Mail | GPG Key (ID / Fingerprint) | GitHub username |
+| ---- | ---- | -----------------------------  | --------------- |
+| Robin Candau | robincandau@protonmail.com | D33FAA16B937F3B2 / A67CCEEBF9613C17FDE96E4ED33FAA16B937F3B2 | @Antiz96 |


### PR DESCRIPTION
This file contains the maintainers that are trusted and are allowed to cut and sign git tags and release artifacts for this project. 
As a user, you can *(and should)* verify that git tags and auto-generated source tarballs on releases (tar.gz archives) for this project are signed by one of the person listed in this file (with the associated GPG key).

If a git tag and/or an auto-generated source tarball (tar.gz archive) contained in a release of this project cannot be verified (e.g. it is not signed / it is signed with a GPG key or by a person that is not listed in this file), the associated tag/release/artifact(s) should not be trusted (starting from now).