### PR TITLE
feat: Add dynamic shell completions for man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install:
 	install -Dm 644 "res/completions/${pkgname}.fish" "${DESTDIR}${PREFIX}/share/fish/vendor_completions.d/${pkgname}.fish"
 
 	# Install man page
-	install -Dm 644 "${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
+	install -Dm 644 "doc/man/${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
 
 	# Install documentation
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"

--- a/res/completions/zaman.bash
+++ b/res/completions/zaman.bash
@@ -1,11 +1,16 @@
 _zaman() {
 	local arg="${2}"
 	local -a opts 
+
 	opts=('-m --menu
 	       -o --output
 	       -O --save
+	       -D --debug
 	       -h --help
 	       -V --version')
+
+	local man_pages=$(man -k . | awk '{print $1}')
+	opts+=("${man_pages}")
 
 	COMPREPLY=( $(compgen -W "${opts[*]}" -- "${arg}") )
 }

--- a/res/completions/zaman.fish
+++ b/res/completions/zaman.fish
@@ -3,5 +3,12 @@ complete -c zaman -f
 complete -c zaman -s m -l menu -d 'Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)'
 complete -c zaman -s o -l output -d '(Args <man page> <file>) Save <man page> into the <file> PDF file'
 complete -c zaman -s O -l save -d '(Arg <man page>) Save <man page> into the "man_<man page>.pdf" file in the current directory'
+complete -c zaman -s D -l debug -d 'Display debug traces'
 complete -c zaman -s h -l help -d 'Display the help message'
 complete -c zaman -s V -l version -d 'Display version information'
+
+function _zaman_man_pages
+	man -k . | awk '{print $1}'
+end
+
+complete -c zaman -a "(_zaman_man_pages)"

--- a/res/completions/zaman.zsh
+++ b/res/completions/zaman.zsh
@@ -5,8 +5,11 @@ opts=(
     {-m,--menu}'[Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)]'
     {-o,--output}'[(Args <man page> <file>) Save <man page> into the <file> PDF file]'
     {-O,--save}'[(Arg <man page>) Save <man page> into the "man_<man page>.pdf" file in the current directory]'
+    {-D,--debug}'[Display debug traces]'
     {-h,--help}'[Display the help message]'
     {-V,--version}'[Display version information]'
 )
 
-_arguments $opts
+local man_pages=(${(f)"$(man -k . | awk '{print $1}')"})
+
+_arguments $opts '*::man-pages:(${man_pages})'


### PR DESCRIPTION
### Description

Add dynamic shell completions for man pages for bash, zsh & fish; so man pages can now be autocompleted with `zaman [TAB]` (the same way it would be done with plain `man`).