### PR TITLE
doc: Update help message and man page

### DIFF
--- a/doc/man/zaman.1.scd
+++ b/doc/man/zaman.1.scd
@@ -2,7 +2,7 @@ zaman(1) ["Zaman 1.3.0" ["Zaman Manual"]]
 
 # NAME
 
-*Zaman* - CLI tool to display (or save) man pages as PDFs.
+*Zaman* - A simple CLI tool to display (or save) man pages as PDFs files.
 
 # DESCRIPTION
 

--- a/src/zaman.sh
+++ b/src/zaman.sh
@@ -35,7 +35,7 @@ esac
 # Definition of the help function: Print the help message
 help() {
 	cat <<EOF
-A simple CLI tool to display (or save) man pages as PDFs files via Zathura for an easier reading.
+A simple CLI tool to display (or save) man pages as PDFs files for an easier reading.
 
 You can directly specify the man page to display as a PDF. For instance, to display the 'ls' man page:
 ${name} ls


### PR DESCRIPTION
### Description

Update help message and man page which were still referring to Zathura as the default PDF reader for Zaman (which is not the case anymore).