### PR TITLE
chore: Get rid of gzip timestamps during build to make Zaman reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	scdoc < "doc/man/${pkgname}.1.scd" > "doc/man/${pkgname}.1"
 	
 	# Archive man page
-	gzip -c "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
+	gzip -nc "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
 
 test:
 	# Run some simple unit tests on basic functions


### PR DESCRIPTION
### Description

`gzip` saves timestamps by default, which prevents reproducible builds.  
Get rid of timestamps with the `-n` option to make Zaman reproducible.