### PR TITLE
chore(man): Don't compress man pages during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ PREFIX ?= /usr/local
 build:
 	# Generate man page
 	scdoc < "doc/man/${pkgname}.1.scd" > "doc/man/${pkgname}.1"
-	
-	# Archive man page
-	gzip -nc "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
 
 test:
 	# Run some simple unit tests on basic functions
@@ -25,14 +22,14 @@ install:
 	install -Dm 644 "res/completions/${pkgname}.fish" "${DESTDIR}${PREFIX}/share/fish/vendor_completions.d/${pkgname}.fish"
 
 	# Install man page
-	install -Dm 644 "doc/man/${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
+	install -Dm 644 "doc/man/${pkgname}.1" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1"
 
 	# Install documentation
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 
 clean:
-	# Delete generated and archived man page
-	rm -f "doc/man/${pkgname}.1"{,.gz}
+	# Delete generated man page
+	rm -f "doc/man/${pkgname}.1"
 
 uninstall:
 	# Delete the main script
@@ -44,7 +41,7 @@ uninstall:
 	rm -f "${DESTDIR}${PREFIX}/share/fish/vendor_completions.d/${pkgname}.fish"
 
 	# Delete man pages
-	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
+	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1"
 
 	# Delete documentation
 	rm -rf "${DESTDIR}${PREFIX}/share/doc/${pkgname}/"


### PR DESCRIPTION
### Description

Compressing man pages is a distribution / user preference that should be handled on the packaging side of things.

Indeed, compressing man pages by default imposes a compression algorithm / level for users whereas most package managers handle that already and allow users to choose / configure them (if wanted at all). Additionally, it can lead to unexpected side effects. For instance, gzip recording timestamps in metadata by default, which prevents reproducible builds (see https://github.com/Antiz96/zaman/commit/51efce8d1671e57c4b02ad783923f1446b927456).

See https://cmpct.info/~sam/blog/posts/automatic-manpage-compression/ for detailed rational.