### PR TITLE
fix: Properly detach the PDF reader process from the terminal session

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later"
 clap = { version = "4.6.1", features = ["derive"] }
 color-eyre = "0.6.5"
 crossterm = "0.29.0"
-nix = { version = "0.31.3", features = ["user"] }
+nix = { version = "0.31.3", features = ["user", "process"] }
 ratatui = "0.30.2"
 
 [dev-dependencies]

--- a/src/open.rs
+++ b/src/open.rs
@@ -1,5 +1,6 @@
 //! Convert the man page as a PDF and open it
 
+use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -19,12 +20,24 @@ pub fn open_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()> {
 
     // Open in PDF reader
     let pdf_reader = get_pdf_reader().map_err(std::io::Error::other)?;
+    let mut command = Command::new(&pdf_reader);
 
-    Command::new(&pdf_reader)
+    command
         .arg(&pdf_path)
+        .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()?;
+        .stderr(Stdio::null());
+
+    // Detach PDF reader process from terminal session
+    unsafe {
+        command.pre_exec(|| {
+            nix::unistd::setsid()
+                .map(|_| ())
+                .map_err(std::io::Error::other)
+        });
+    }
+
+    command.spawn()?;
 
     Ok(())
 }


### PR DESCRIPTION
### Description

Properly detach the PDF reader process from the terminal session.

This allows to run and use `manora` from keybindings, e.g. by associating a keybind to the `alacritty -e manora` command which will open the manora TUI menu in alacritty allowing and select the man page to open in the PDF reader (and properly close the terminal once the man page has been selected).