### PR TITLE
doc: Document the possibility to run from keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@
 
 A simple CLI / TUI tool to display (or save) man pages as PDF files for an easier reading.
 
-Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.  
-It also allows to navigate through all the man pages available on the system through TUI menu (made with [Ratatui](https://ratatui.rs/)).
+Run the `manora` command to display a list of all the available man pages on the system in a TUI menu (made with [Ratatui](https://ratatui.rs/), allowing to search for the one to display as a PDF.  
+Alternatively, specify the man page to open directly as an argument (e.g. `manora ls`).
+
+Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.
 
 <https://github.com/user-attachments/assets/c173aa9f-90e1-4744-9b76-cfdf4cf05a3f>
+
+Manora can also be ran from keybindings. For instance, one can bind the `alacritty -e manora` command to a keybind, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
 
 ## Installation
 
@@ -78,14 +82,17 @@ There are also shell completions available in the [`res/completions/`](https://g
 
 ## Usage
 
-Run the `manora` command in your terminal to display a list of all the available man pages on your system in a TUI menu, allowing you to search for the one to display as a PDF. Alternatively, specify the man page to open directly as an argument (e.g. `manora ls`).
+Run the `manora` command to display a list of all the available man pages on the system in a TUI menu, allowing to search for the one to display as a PDF.  
+Alternatively, specify the man page to open directly as an argument (e.g. `manora ls`).
 
-Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.  
+Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.
 
-To save / export a man page locally as a PDF file, run `manora --save <man_page>` where `<man_page>` is the man page to save (e.g. `manora --save ls`).  
+To save / export a man page to a local PDF file, run `manora --save <man_page>` where `<man_page>` is the man page to save (e.g. `manora --save ls`).  
 The file will be saved as `man_<man_page>.pdf` (e.g. `man_ls.pdf`) in the current directory.  
 
-You can optionally specify the file to save the man page to: `manora --save <man_page> <file>` (e.g. `manora --save ls ~/Documents/man_pages/ls.pdf`).
+Alternatively, specify the file to save the man page to: `manora --save <man_page> <file>` (e.g. `manora --save ls ~/Documents/man_pages/ls.pdf`).
+
+Manora can also be ran from keybindings. For instance, one can bind the `alacritty -e manora` command to a keybind, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
 
 See `manora --help`, the [manora(1) man page](https://raw.githubusercontent.com/Antiz96/manora/refs/heads/main/doc/man/manora.1.scd) and the [demo video](#description) for more details.
 

--- a/doc/man/manora.1.scd
+++ b/doc/man/manora.1.scd
@@ -8,8 +8,12 @@ manora(1) ["Manora 2.0.1" ["Manora Manual"]]
 
 A simple CLI / TUI tool to display (or save) man pages as PDF files for an easier reading.
 
+Run the `manora` command to display a list of all the available man pages on the system in a TUI menu, allowing to search for the one to display as a PDF.
+Alternatively, specify the man page to open directly as an argument (e.g. `manora ls`).
+
 Manora opens man pages in the default PDF reader defined in XDG MIME Applications, or fallback to Zathura if no default PDF reader is set.  
-It also allows to navigate through all the man pages available on the system through a TUI menu.
+
+Manora can also be ran from keybindings. For instance, one can bind the `alacritty -e manora` command to a keybind, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
 
 # SYNOPSIS
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -3,8 +3,12 @@
 pub fn show_help() {
     println!("manora - A simple CLI / TUI tool to display (or save) man pages as PDF files");
     println!();
-    println!("You can directly specify the man page to display as a PDF.");
-    println!("For instance, to display the 'ls' man page: manora ls");
+    println!(
+        "Run the `manora` command to display a list of all the available man pages on the system in a TUI menu, allowing to search for the one to display as a PDF."
+    );
+    println!(
+        "Alternatively, specify the man page to open directly as an argument (e.g. `manora ls`)."
+    );
     println!();
     println!("Options:");
     println!(


### PR DESCRIPTION
### Description

Manora can be also ran from keybindings. For instance, one can bind the `alacritty -e manora` command to a keybind, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).

Also add some small wording improvements to the documentation.