### PR TITLE
feat: Add the `-d / --download` option to force downloading from https://manned.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Alternatively, specify the man page to open directly as an argument (e.g. `manor
 
 Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.
 
-Manora can also save / export man pages to a local PDF file, it offers to download man pages that cannot be found locally (from <https://manned.org>) and can be ran from a keybinding.
+Manora can also save / export man pages to a local PDF file, download man pages from <https://manned.org> (if requested or offered as a fallback option if the targeted man page cannot be found locally) and can be opened from a keybinding.
 
 See the "[Usage](#usage)" chapter and the demo video below for more details:
 
@@ -89,14 +89,15 @@ Alternatively, specify the man page to open directly as an argument (e.g. `manor
 
 Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.
 
-To save / export a man page to a local PDF file, run `manora --save <man_page>` where `<man_page>` is the man page to save (e.g. `manora --save ls`).  
-The file will be saved as `man_<man_page>.pdf` (e.g. `man_ls.pdf`) in the current directory.  
+To save / export a man page to a local PDF file, run `manora --save <man page>` where `<man page>` is the man page to save (e.g. `manora --save ls`).  
+The file will be saved as `man_<man page>.pdf` (e.g. `man_ls.pdf`) in the current directory.  
 
-Alternatively, specify the file to save the man page to: `manora --save <man_page> <file>` (e.g. `manora --save ls ~/Documents/man_pages/ls.pdf`).
+Alternatively, specify the file to save the man page to: `manora --save <man page> <file>` (e.g. `manora --save ls ~/Documents/man_pages/ls.pdf`).
 
-If a man page cannot be found locally, Manora offers to (try to) download it from <https://manned.org> (whether it is to open or save it).
+If a man page cannot be found locally, Manora offers to (try to) download it from <https://manned.org> (whether it is to open or save it).  
+Use the `-d / --download` option to skip local man pages lookup and directly try to download the man page from <https://manned.org> instead, (e.g. `manora --download ls` / `manora --download --save ls`).
 
-Manora can also be ran from a keybinding. For instance, one can bind the `alacritty -e manora` command to a keybinding, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
+Manora can also be opened from a keybinding. For instance, one can bind the `alacritty -e manora` command to a keybinding, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
 
 See `manora --help`, the [manora(1) man page](https://raw.githubusercontent.com/Antiz96/manora/refs/heads/main/doc/man/manora.1.scd) and the [demo video](#description) for more details.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Alternatively, specify the man page to open directly as an argument (e.g. `manor
 
 Manora opens man pages in the default PDF reader defined in [XDG MIME Applications](https://wiki.archlinux.org/title/XDG_MIME_Applications), or fallback to [Zathura](https://pwmt.org/projects/zathura/) if no default PDF reader is set.
 
-Manora can also save / export man pages to a local PDF file, download man pages from <https://manned.org> (if requested or offered as a fallback option if the targeted man page cannot be found locally) and can be opened from a keybinding.
+Manora can also save / export man pages to a local PDF file, download man pages from <https://manned.org> and be opened from a keybinding.
 
 See the "[Usage](#usage)" chapter and the demo video below for more details:
 
@@ -94,7 +94,7 @@ The file will be saved as `man_<man page>.pdf` (e.g. `man_ls.pdf`) in the curren
 
 Alternatively, specify the file to save the man page to: `manora --save <man page> <file>` (e.g. `manora --save ls ~/Documents/man_pages/ls.pdf`).
 
-If a man page cannot be found locally, Manora offers to (try to) download it from <https://manned.org> (whether it is to open or save it).  
+If a man page cannot be found locally, Manora offers to try to download it from <https://manned.org> (whether it is to open or save it).  
 Use the `-d / --download` option to skip local man pages lookup and directly try to download the man page from <https://manned.org> instead, (e.g. `manora --download ls` / `manora --download --save ls`).
 
 Manora can also be opened from a keybinding. For instance, one can bind the `alacritty -e manora` command to a keybinding, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).

--- a/doc/man/manora.1.scd
+++ b/doc/man/manora.1.scd
@@ -13,7 +13,7 @@ Alternatively, specify the man page to open directly as an argument (e.g. `manor
 
 Manora opens man pages in the default PDF reader defined in XDG MIME Applications, or fallback to Zathura if no default PDF reader is set.  
 
-Manora can also be ran from keybindings. For instance, one can bind the `alacritty -e manora` command to a keybind, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
+Manora can also be opened from a keybinding. For instance, one can bind the `alacritty -e manora` command to a keybind, which will open the `manora` TUI menu in `alacritty` (allowing to select the man page to open in the PDF reader).
 
 # SYNOPSIS
 
@@ -24,9 +24,13 @@ Manora can also be ran from keybindings. For instance, one can bind the `alacrit
 *-m, --menu*
 	Display the list of all the available man pages in a TUI, allowing you to search for the one to display as a PDF (default operation).
 
-*-s, --save* <man_page> <file>
+*-s, --save* <man page> <file>
 	Save <man page> into the <file> PDF file.
 	If <file> isn't specified, save it to a "man_<man page>.pdf" file in the current directory.
+
+*-d, --download* <option> <man page>
+	Skip local man pages lookup and directly try to download the man page from <https://manned.org> instead.
+	This option can be used when specifying a man page to open as an argument (`manora --download <man page>`) or in combination with the `-s / --save` option (`manora --download --save <man page>`).
 
 *-V, --version*
 	Display version information.

--- a/res/completions/manora.bash
+++ b/res/completions/manora.bash
@@ -4,6 +4,7 @@ _manora() {
 
 	opts=('-m --menu
 	       -s --save
+	       -d --download
 	       -h --help
 	       -V --version')
 

--- a/res/completions/manora.fish
+++ b/res/completions/manora.fish
@@ -2,6 +2,7 @@ complete -c manora -f
 
 complete -c manora -s m -l menu -d 'Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)'
 complete -c manora -s s -l save -d '(Arg <man page> <file>) Save <man page> into the <file> PDF file (or a "man_<man page>.pdf" file if <file> is not specified)'
+complete -c manora -s d -l download -d 'Skip local man pages lookup and directly try to download the mange page from <https://manned.org> instead (e.g. "manora --download <man page>" or "manora --download --save <man page>"'
 complete -c manora -s h -l help -d 'Display the help message'
 complete -c manora -s V -l version -d 'Display version information'
 

--- a/res/completions/manora.fish
+++ b/res/completions/manora.fish
@@ -2,7 +2,7 @@ complete -c manora -f
 
 complete -c manora -s m -l menu -d 'Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)'
 complete -c manora -s s -l save -d '(Arg <man page> <file>) Save <man page> into the <file> PDF file (or a "man_<man page>.pdf" file if <file> is not specified)'
-complete -c manora -s d -l download -d 'Skip local man pages lookup and directly try to download the mange page from <https://manned.org> instead (e.g. "manora --download <man page>" or "manora --download --save <man page>"'
+complete -c manora -s d -l download -d 'Skip local man pages lookup and directly try to download the man page from <https://manned.org> instead (e.g. "manora --download <man page>" or "manora --download --save <man page>")'
 complete -c manora -s h -l help -d 'Display the help message'
 complete -c manora -s V -l version -d 'Display version information'
 

--- a/res/completions/manora.zsh
+++ b/res/completions/manora.zsh
@@ -4,7 +4,7 @@ local -a opts
 opts=(
     {-m,--menu}'[Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)]'
     {-s,--save}'[(Arg <man page> <file>) Save <man page> into the <file> PDF file (or a "man_<man page>.pdf" file if <file> is not specified)]'
-    {-d,--download}'[Skip local man pages lookup and directly try to download the mange page from <https://manned.org> instead (e.g. "manora --download <man page>" or "manora --download --save <man page>"]'
+    {-d,--download}'[Skip local man pages lookup and directly try to download the man page from <https://manned.org> instead (e.g. "manora --download <man page>" or "manora --download --save <man page>")]'
     {-h,--help}'[Display the help message]'
     {-V,--version}'[Display version information]'
 )

--- a/res/completions/manora.zsh
+++ b/res/completions/manora.zsh
@@ -4,6 +4,7 @@ local -a opts
 opts=(
     {-m,--menu}'[Print a menu via rofi or dmenu that lists every man pages to choose from (default operation)]'
     {-s,--save}'[(Arg <man page> <file>) Save <man page> into the <file> PDF file (or a "man_<man page>.pdf" file if <file> is not specified)]'
+    {-d,--download}'[Skip local man pages lookup and directly try to download the mange page from <https://manned.org> instead (e.g. "manora --download <man page>" or "manora --download --save <man page>"]'
     {-h,--help}'[Display the help message]'
     {-V,--version}'[Display version information]'
 )

--- a/src/help.rs
+++ b/src/help.rs
@@ -13,7 +13,7 @@ pub fn show_help() {
     );
     println!();
     println!(
-        "If a man page cannot be found locally, Manora offers to (try to) download it from <https://manned.org>."
+        "If a man page cannot be found locally, Manora offers to try to download it from <https://manned.org>."
     );
     println!();
     println!("Options:");

--- a/src/help.rs
+++ b/src/help.rs
@@ -23,6 +23,9 @@ pub fn show_help() {
     println!(
         "  -s, --save <man page> <file>  Save <man page> into the <file> PDF file. If <file> isn't specified, save it to a \"man_<man page>.pdf\" file in the current directory"
     );
+    println!(
+        "  -d, --download                Skip local man pages lookup and directly try to download the man page from <https://manned.org> instead, this option can be used when specifying a man page to open as an argument (`manora --download <man page>`) or in combination with the `-s / --save` option (`manora --download --save <man page>`)"
+    );
     println!("  -h, --help                    Display this message");
     println!("  -V, --version                 Display version information");
     println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,9 @@ struct Args {
     #[arg(short = 's', long)]
     save: bool,
 
+    #[arg(short = 'd', long)]
+    download: bool,
+
     #[arg(short = 'h', long)]
     help: bool,
 
@@ -42,13 +45,92 @@ struct Args {
 fn main() {
     // Parse arguments
     let args = Args::parse();
-    let no_args =
-        args.pos_args.is_empty() && !args.menu && !args.save && !args.help && !args.version;
+    let no_args = args.pos_args.is_empty()
+        && !args.menu
+        && !args.save
+        && !args.download
+        && !args.help
+        && !args.version;
 
     // Define empty (optional) and mutable man_page variable
-    // Will be set either from the menu or the first CLI argument
+    // Will be set either from the menu or the first positional CLI argument
     let mut man_page: Option<String> = None;
 
+    // Show help message if the -h / --help arg is passed
+    if args.help {
+        help::show_help();
+        return;
+    }
+
+    // Show name and version if the -V / --version arg is passed
+    if args.version {
+        version::show_version();
+        return;
+    }
+
+    // Force download man page from https://manned.org if the -d / --download argument is passed
+    if args.download {
+        let man_page = args.pos_args.first().cloned().unwrap_or_else(|| {
+            eprintln!("Missing man page\nTry 'manora --help' for more information");
+            process::exit(3);
+        });
+
+        // Create cache directory (if it doesn't exist)
+        // Needed to store the downloaded man page
+        let cachedir = cachedir::create_cachedir().unwrap_or_else(|error| {
+            eprintln!("Failed to create the cache directory:\n{}", error);
+            process::exit(4);
+        });
+
+        download::download_man_page(&man_page, &cachedir).unwrap_or_else(|error| {
+            eprintln!("Failed to download the man page:\n{}", error);
+            process::exit(5);
+        });
+
+        if args.save {
+            let file = args
+                .pos_args
+                .get(1)
+                .cloned()
+                .unwrap_or_else(|| format!("man_{}.pdf", man_page));
+
+            let path = Path::new(&file);
+
+            if path.exists() {
+                print!("The {} file already exists\nOverwrite? [y/N] ", file);
+                io::stdout().flush().unwrap();
+
+                let mut answer = String::new();
+                io::stdin().read_line(&mut answer).unwrap();
+
+                if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+                    eprintln!("\nAborted");
+                    process::exit(3);
+                } else {
+                    println!();
+                }
+            }
+
+            save::save_downloaded_man_page(&man_page, &cachedir, Path::new(&file)).unwrap_or_else(
+                |error| {
+                    eprintln!("Failed to save the man page:\n{}", error);
+                    process::exit(3);
+                },
+            );
+
+            println!(
+                "The {} man page has been downloaded from https://manned.org and saved to the {} file",
+                man_page, file
+            );
+        } else {
+            open::open_downloaded_man_page(&man_page, &cachedir).unwrap_or_else(|error| {
+                eprintln!("Failed to open the man page:\n{}", error);
+                process::exit(1);
+            });
+        }
+
+        return;
+    }
     // Show TUI menu to choose man page if the -m / --menu arg (or no arg) is passed
     if args.menu || no_args {
         match menu::show_menu() {
@@ -136,18 +218,6 @@ fn main() {
             "The {} man page has been saved to the {} file",
             man_page, file
         );
-        return;
-    }
-
-    // Show help message if the -h / --help arg is passed
-    if args.help {
-        help::show_help();
-        return;
-    }
-
-    // Show name and version if the -V / --version arg is passed
-    if args.version {
-        version::show_version();
         return;
     }
 


### PR DESCRIPTION
### Description

Add the new `-d / --download` option flag to skip local man pages lookup and directly try to download the man page from <https://manned.org> instead.

This option can be used when specifying the man page to open as an argument (`manora --download <man page>`) or in combination with the `-s / --save` option (`manora --download --save <man page>`).

### Screenshots

<img width="1898" height="1035" alt="image" src="https://github.com/user-attachments/assets/9f99c27d-5849-4e71-8ecb-2653721e5c53" />

<img width="1898" height="1035" alt="image" src="https://github.com/user-attachments/assets/e55f421d-2261-444a-9d32-71cbcb799c3e" />
