### PR TITLE
chore: Refactor imports

### DIFF
--- a/src/cachedir.rs
+++ b/src/cachedir.rs
@@ -1,11 +1,13 @@
 //! Create cache directory (if it doesn't exist):
 //! ${TMPDIR:-/tmp}/manora-${UID}
 
+use nix::unistd::Uid;
+use std::io;
 use std::path::PathBuf;
 use std::{env, fs};
 
-pub fn create_cachedir() -> std::io::Result<PathBuf> {
-    let uid = nix::unistd::Uid::effective();
+pub fn create_cachedir() -> io::Result<PathBuf> {
+    let uid = Uid::effective();
 
     let tmpdir = env::var("TMPDIR")
         .ok()

--- a/src/download.rs
+++ b/src/download.rs
@@ -2,22 +2,23 @@
 //! and convert it to PDF (in case it cannot be found locally)
 
 use reqwest::blocking::get;
-use std::io::Write;
+use std::fs;
+use std::io::{self, Error, ErrorKind, Write};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
-pub fn download_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()> {
+pub fn download_man_page(man_page: &str, cachedir: &Path) -> io::Result<()> {
     // Try to download raw man page
     let url = format!("https://manned.org/raw/{}", man_page);
     let raw_man_page = get(&url)
-        .map_err(std::io::Error::other)?
+        .map_err(Error::other)?
         .text()
-        .map_err(std::io::Error::other)?;
+        .map_err(Error::other)?;
 
     // Check if the man page was found
     if raw_man_page.contains("the page you were looking for doesn't exist.") {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
+        return Err(Error::new(
+            ErrorKind::NotFound,
             format!(
                 "No manual entry found on https://manned.org for {}",
                 man_page
@@ -28,27 +29,27 @@ pub fn download_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()>
     // Convert raw_man_page to PDF
     let mut conversion = Command::new("groff")
         .args(["-mandoc", "-Tpdf"])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
         .spawn()?;
 
     conversion
         .stdin
         .take()
-        .ok_or_else(|| std::io::Error::other("Failed to access groff stdin"))?
+        .ok_or_else(|| Error::other("Failed to access groff stdin"))?
         .write_all(raw_man_page.as_bytes())?;
 
     let conversion_output = conversion.wait_with_output()?;
 
     if !conversion_output.status.success() {
-        return Err(std::io::Error::other(
+        return Err(Error::other(
             String::from_utf8_lossy(&conversion_output.stderr).to_string(),
         ));
     }
 
     // Save converted man page in cache directory
     let dest_file_path = cachedir.join(format!("{}.pdf", man_page));
-    std::fs::write(dest_file_path, conversion_output.stdout)?;
+    fs::write(dest_file_path, conversion_output.stdout)?;
 
     Ok(())
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -2,10 +2,11 @@
 //! Built with ratatui, inspired / based on the list widget example
 //! https://ratatui.rs/examples/widgets/list/
 
+use color_eyre::eyre;
 use crossterm::event::{self, KeyCode};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
-use ratatui::style::{Color, Modifier, Stylize};
+use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{List, ListState, Paragraph};
 use std::process::Command;
@@ -86,7 +87,7 @@ pub fn show_menu() -> color_eyre::Result<(String, bool)> {
                         };
                     }
                     KeyCode::Esc => {
-                        break Err(color_eyre::eyre::eyre!("No man page selected"));
+                        break Err(eyre::eyre!("No man page selected"));
                     }
                     _ => {}
                 }
@@ -209,7 +210,7 @@ fn render(frame: &mut Frame, app: &App, list_state: &mut ListState, mode: Mode) 
     frame.render_widget(Paragraph::new(mode_desc).centered(), mode_desc_area);
 
     let search = Paragraph::new(Line::from(vec![
-        Span::styled("Search: ", ratatui::style::Style::default().bold()),
+        Span::styled("Search: ", Style::default().bold()),
         Span::raw(&app.query),
     ]));
     frame.render_widget(search, search_area);

--- a/src/open.rs
+++ b/src/open.rs
@@ -1,27 +1,30 @@
 //! Convert the man page as a PDF and open it
 
+use nix::unistd;
+use std::fs;
+use std::io::{self, Error, ErrorKind};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
 // Open man page as a PDF
-pub fn open_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()> {
+pub fn open_man_page(man_page: &str, cachedir: &Path) -> io::Result<()> {
     // Convert man page as a PDF
     let conversion = Command::new("man").args(["-Tpdf", man_page]).output()?;
 
     if !conversion.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
+        return Err(Error::new(
+            ErrorKind::NotFound,
             String::from_utf8_lossy(&conversion.stderr).to_string(),
         ));
     }
 
     // Save the converted man page as a PDF file in the cachedir
     let dest_file_path = cachedir.join(format!("{}.pdf", man_page));
-    std::fs::write(&dest_file_path, conversion.stdout)?;
+    fs::write(&dest_file_path, conversion.stdout)?;
 
     // Open in PDF reader
-    let pdf_reader = get_pdf_reader().map_err(std::io::Error::other)?;
+    let pdf_reader = get_pdf_reader().map_err(Error::other)?;
     let mut open = Command::new(&pdf_reader);
 
     open.arg(&dest_file_path)
@@ -31,11 +34,7 @@ pub fn open_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()> {
 
     // Detach PDF reader process from terminal session
     unsafe {
-        open.pre_exec(|| {
-            nix::unistd::setsid()
-                .map(|_| ())
-                .map_err(std::io::Error::other)
-        });
+        open.pre_exec(|| unistd::setsid().map(|_| ()).map_err(Error::other));
     }
 
     open.spawn()?;
@@ -44,12 +43,12 @@ pub fn open_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()> {
 }
 
 // Open downloaded man page as a PDF
-pub fn open_downloaded_man_page(man_page: &str, cachedir: &Path) -> std::io::Result<()> {
+pub fn open_downloaded_man_page(man_page: &str, cachedir: &Path) -> io::Result<()> {
     // Set path to downloaded man page
     let dest_file_path = cachedir.join(format!("{}.pdf", man_page));
 
     // Open in PDF reader
-    let pdf_reader = get_pdf_reader().map_err(std::io::Error::other)?;
+    let pdf_reader = get_pdf_reader().map_err(Error::other)?;
     let mut open = Command::new(&pdf_reader);
 
     open.arg(&dest_file_path)
@@ -59,11 +58,7 @@ pub fn open_downloaded_man_page(man_page: &str, cachedir: &Path) -> std::io::Res
 
     // Detach PDF reader process from terminal session
     unsafe {
-        open.pre_exec(|| {
-            nix::unistd::setsid()
-                .map(|_| ())
-                .map_err(std::io::Error::other)
-        });
+        open.pre_exec(|| unistd::setsid().map(|_| ()).map_err(Error::other));
     }
 
     open.spawn()?;

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,22 +1,24 @@
 //! Save man page to a PDF file
 
+use std::fs;
+use std::io::{self, Error, ErrorKind};
 use std::path::Path;
 use std::process::Command;
 
 // Save man pas as a PDF
-pub fn save_man_page(man_page: &str, dest_file_path: &Path) -> std::io::Result<()> {
+pub fn save_man_page(man_page: &str, dest_file_path: &Path) -> io::Result<()> {
     // Convert man page as a PDF
     let conversion = Command::new("man").args(["-Tpdf", man_page]).output()?;
 
     if !conversion.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
+        return Err(Error::new(
+            ErrorKind::NotFound,
             String::from_utf8_lossy(&conversion.stderr).to_string(),
         ));
     }
 
     // Save the converted man page as a PDF file
-    std::fs::write(dest_file_path, conversion.stdout)?;
+    fs::write(dest_file_path, conversion.stdout)?;
 
     Ok(())
 }
@@ -26,7 +28,7 @@ pub fn save_downloaded_man_page(
     man_page: &str,
     cachedir: &Path,
     dest_file_path: &Path,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     // Set path to downloaded man page
     let dl_man_page_file_path = cachedir.join(format!("{}.pdf", man_page));
 
@@ -34,8 +36,8 @@ pub fn save_downloaded_man_page(
     // Using "copy" then "remove_file" functions instead of "rename" function
     // as the latter requires the source and destination to be on the same filesystem
     // while cachedir is in /tmp (which is likely tmpfs)
-    std::fs::copy(&dl_man_page_file_path, dest_file_path)?;
-    std::fs::remove_file(dl_man_page_file_path)?;
+    fs::copy(&dl_man_page_file_path, dest_file_path)?;
+    fs::remove_file(dl_man_page_file_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
### Description

Refactor imports and function calls to adopt a more concise yet still meaningful style.

General guidelines:
- Import modules (using `use ...`) at the top.
- When calling a function, keep module name when it provides useful context / provenance, e.g. `env::var()`, `io::stdout()`, `fs::read_to_string()`.
- If the function has an associated type, prefer using function name + type directly instead, e.g. `ErrorKind::NotFound`, `HashMap::new()`, `PathBuf::from()`, `Uid::effective()`.

As a *general* rule of thumb, avoid deeply qualified paths and aim for roughly one `::` per call (e.g. prefer `ErrorKind::NotFound` over `std::io::ErrorKind::NotFound`).

Exceptions can be made fine when it avoids ambiguity (such as conflicting functions names, e.g. `std::thread::sleep` vs `tokio::time::sleep`), or when a function call is already clear (from name or context) and the refactor doesn't bring much (for instance, the single `get(&url)` call from the current codebase).